### PR TITLE
Fix nix missing dependencies error

### DIFF
--- a/tete.cabal
+++ b/tete.cabal
@@ -80,7 +80,7 @@ library
 
     -- Other library packages from which modules are imported.
     build-depends:
-      base ^>=4.18.2.1,
+      base,
       boxes,
       containers,
       directory,
@@ -112,7 +112,7 @@ executable tete
 
     -- Other library packages from which modules are imported.
     build-depends:
-      base ^>=4.18.2.1,
+      base,
       tete,
       boxes,
       containers,
@@ -154,7 +154,7 @@ test-suite tete-test
 
     -- Test dependencies.
     build-depends:
-        base ^>=4.18.2.1,
+        base,
         containers,
         hspec,
         tete,


### PR DESCRIPTION
Nix throws this error when installing in NixOS using `haskellPackages.mkDerivation`:
```
       > Error: Setup: Encountered missing or private dependencies:
       > boxes, extra, hspec, optparse-applicative, sqlite-simple
```